### PR TITLE
Traducción del capítulo 17

### DIFF
--- a/src/ch17-01-what-is-oo.md
+++ b/src/ch17-01-what-is-oo.md
@@ -1,48 +1,51 @@
-## Characteristics of Object-Oriented Languages
+## Características de lenguajes orientados a objetos
 
-There is no consensus in the programming community about what features a
-language must have to be considered object-oriented. Rust is influenced by many
-programming paradigms, including OOP; for example, we explored the features
-that came from functional programming in Chapter 13. Arguably, OOP languages
-share certain common characteristics, namely objects, encapsulation, and
-inheritance. Let’s look at what each of those characteristics means and whether
-Rust supports it.
+No hay consenso en la comunidad de programación sobre qué características debe
+tener un lenguaje para ser considerado orientado a objetos. Rust está
+influenciado por muchos paradigmas de programación, incluido OOP; por ejemplo,
+exploramos las características que provienen de la programación funcional en el
+Capítulo 13. Es discutible que los lenguajes OOP compartan ciertas
+características comunes, a saber, objetos, encapsulación y herencia. Veamos qué
+significa cada una de esas características y si Rust la admite.
 
-### Objects Contain Data and Behavior
+### Los objetos contienen datos y comportamiento
 
-The book *Design Patterns: Elements of Reusable Object-Oriented Software* by
-Erich Gamma, Richard Helm, Ralph Johnson, and John Vlissides (Addison-Wesley
-Professional, 1994), colloquially referred to as *The Gang of Four* book, is a
-catalog of object-oriented design patterns. It defines OOP this way:
+El libro *Design Patterns: Elements of Reusable Object-Oriented Software* de
+Erich Gamma, Richard Helm, Ralph Johnson y John Vlissides (Addison-Wesley
+Professional, 1994), coloquialmente conocido como el libro *Gang of Four*, es un
+catálogo de patrones de diseño orientados a objetos. Define OOP de esta manera:
 
-> Object-oriented programs are made up of objects. An *object* packages both
-> data and the procedures that operate on that data. The procedures are
-> typically called *methods* or *operations*.
+> Los programas orientados a objetos están compuestos por objetos. Un *objeto*
+> empaqueta tanto datos como los procedimientos que operan en esos datos. Los
+> procedimientos se denominan típicamente *métodos* u *operaciones*.
 
-Using this definition, Rust is object-oriented: structs and enums have data,
-and `impl` blocks provide methods on structs and enums. Even though structs and
-enums with methods aren’t *called* objects, they provide the same
-functionality, according to the Gang of Four’s definition of objects.
+Usando esta definición, Rust es orientado a objetos: los structs y los
+enums tienen datos, y los bloques `impl` proporcionan métodos en structs y 
+enums. Aunque los structs y los enums con métodos no se llaman objetos, 
+proporcionan la misma funcionalidad, según la definición de objetos del 
+Gang of Four’s.
 
-### Encapsulation that Hides Implementation Details
+### Encapsulación que oculta los detalles de implementación
 
-Another aspect commonly associated with OOP is the idea of *encapsulation*,
-which means that the implementation details of an object aren’t accessible to
-code using that object. Therefore, the only way to interact with an object is
-through its public API; code using the object shouldn’t be able to reach into
-the object’s internals and change data or behavior directly. This enables the
-programmer to change and refactor an object’s internals without needing to
-change the code that uses the object.
+Otro aspecto comúnmente asociado con OOP es la idea de *encapsulación*, que
+significa que los detalles de implementación de un objeto no son accesibles al
+código que usa ese objeto. Por lo tanto, la única forma de interactuar con un
+objeto es a través de su API pública; el código que usa el objeto no debería
+poder acceder a los detalles internos del objeto y cambiar los datos o el
+comportamiento directamente. Esto permite al programador cambiar y refactorizar
+los detalles internos de un objeto sin necesidad de cambiar el código que usa
+el objeto.
 
-We discussed how to control encapsulation in Chapter 7: we can use the `pub`
-keyword to decide which modules, types, functions, and methods in our code
-should be public, and by default everything else is private. For example, we
-can define a struct `AveragedCollection` that has a field containing a vector
-of `i32` values. The struct can also have a field that contains the average of
-the values in the vector, meaning the average doesn’t have to be computed
-on demand whenever anyone needs it. In other words, `AveragedCollection` will
-cache the calculated average for us. Listing 17-1 has the definition of the
-`AveragedCollection` struct:
+Hemos discutido cómo controlar la encapsulación en el Capítulo 7: podemos usar
+la palabra clave `pub` para decidir qué módulos, tipos, funciones y métodos en
+nuestro código deben ser públicos, y por defecto todo lo demás es privado. Por
+ejemplo, podemos definir un struct `AveragedCollection` que tiene un campo que
+contiene un vector de valores `i32`. El struct también puede tener un campo que
+contiene el promedio de los valores en el vector, lo que significa que el
+promedio no tiene que calcularse a pedido cada vez que alguien lo necesite. En
+otras palabras, `AveragedCollection` almacenará en caché el promedio calculado
+para nosotros. El Listado 17-1 tiene la definición del struct 
+`AveragedCollection`:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -50,15 +53,16 @@ cache the calculated average for us. Listing 17-1 has the definition of the
 {{#rustdoc_include ../listings/ch17-oop/listing-17-01/src/lib.rs}}
 ```
 
-<span class="caption">Listing 17-1: An `AveragedCollection` struct that
-maintains a list of integers and the average of the items in the
-collection</span>
+<span class="caption">Listing 17-1: Un struct `AveragedCollection` que
+mantiene una lista de enteros y el promedio de los elementos en la colección
+</span>
 
-The struct is marked `pub` so that other code can use it, but the fields within
-the struct remain private. This is important in this case because we want to
-ensure that whenever a value is added or removed from the list, the average is
-also updated. We do this by implementing `add`, `remove`, and `average` methods
-on the struct, as shown in Listing 17-2:
+El struct está marcado como `pub` para que otro código pueda usarlo, pero los
+campos dentro del struct permanecen privados. Esto es importante en este caso
+porque queremos asegurarnos de que cada vez que se agrega o elimina un valor de
+la lista, el promedio también se actualiza. Hacemos esto implementando los
+métodos públicos `add`, `remove` y `average` en el struct, como se muestra en
+el Listado 17-2:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -66,87 +70,94 @@ on the struct, as shown in Listing 17-2:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-02/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-2: Implementations of the public methods
-`add`, `remove`, and `average` on `AveragedCollection`</span>
+<span class="caption">Listing 17-2: Implementaciones de los métodos públicos
+`add`, `remove`, y `average` en `AveragedCollection`</span>
 
-The public methods `add`, `remove`, and `average` are the only ways to access
-or modify data in an instance of `AveragedCollection`. When an item is added
-to `list` using the `add` method or removed using the `remove` method, the
-implementations of each call the private `update_average` method that handles
-updating the `average` field as well.
+Los métodos públicos `add`, `remove`, y `average` son las únicas formas de
+acceder o modificar los datos en una instancia de `AveragedCollection`. Cuando
+se agrega un elemento a `list` usando el método `add` o se elimina usando el
+método `remove`, las implementaciones de cada uno llaman al método privado
+`update_average` que maneja la actualización del campo `average` también.
 
-We leave the `list` and `average` fields private so there is no way for
-external code to add or remove items to or from the `list` field directly;
-otherwise, the `average` field might become out of sync when the `list`
-changes. The `average` method returns the value in the `average` field,
-allowing external code to read the `average` but not modify it.
+Dejamos los campos `list` y `average` privados para que no haya forma de que el
+código externo agregue o elimine elementos de `list` directamente; de lo
+contrario, el campo `average` podría quedar fuera de sincronización cuando
+`list` cambia. El método `average` devuelve el valor en el campo `average`,
+permitiendo que el código externo lea el `average` pero no lo modifique.
 
-Because we’ve encapsulated the implementation details of the struct
-`AveragedCollection`, we can easily change aspects, such as the data structure,
-in the future. For instance, we could use a `HashSet<i32>` instead of a
-`Vec<i32>` for the `list` field. As long as the signatures of the `add`,
-`remove`, and `average` public methods stay the same, code using
-`AveragedCollection` wouldn’t need to change. If we made `list` public instead,
-this wouldn’t necessarily be the case: `HashSet<i32>` and `Vec<i32>` have
-different methods for adding and removing items, so the external code would
-likely have to change if it were modifying `list` directly.
+Debido a que hemos encapsulado la implementación de `AveragedCollection`, podemos
+cambiar fácilmente los aspectos, como la estructura de datos, en el futuro. Por
+ejemplo, podríamos usar un `HashSet<i32>` en lugar de un `Vec<i32>` para el
+campo `list`. Mientras las firmas de los métodos públicos `add`, `remove`, y
+`average` permanezcan iguales, el código que usa `AveragedCollection` no
+necesitaría cambiar. Si hicimos `list` pública en su lugar, esto no sería
+necesariamente cierto: `HashSet<i32>` y `Vec<i32>` tienen diferentes métodos
+para agregar y eliminar elementos, por lo que el código externo probablemente
+tendría que cambiar si estuviera modificando `list` directamente.
 
-If encapsulation is a required aspect for a language to be considered
-object-oriented, then Rust meets that requirement. The option to use `pub` or
-not for different parts of code enables encapsulation of implementation details.
+Si la encapsulación es un aspecto requerido para que un lenguaje se considere
+orientado a objetos, entonces Rust cumple con ese requisito. La opción de usar
+`pub` o no para diferentes partes del código permite la encapsulación de los
+detalles de implementación.
 
-### Inheritance as a Type System and as Code Sharing
+### Herencia como un sistema de tipos y como Code Sharing
 
-*Inheritance* is a mechanism whereby an object can inherit elements from
-another object’s definition, thus gaining the parent object’s data and behavior
-without you having to define them again.
+*Herencia* es un mecanismo mediante el cual un objeto puede heredar elementos de
+la definición de otro objeto, obteniendo así los datos y el comportamiento del
+objeto padre sin tener que definirlos nuevamente.
 
-If a language must have inheritance to be an object-oriented language, then
-Rust is not one. There is no way to define a struct that inherits the parent
-struct’s fields and method implementations without using a macro.
+Si se considera que un lenguaje debe tener herencia para ser un lenguaje
+orientado a objetos, entonces Rust no cumple con esta definición. No existe
+una forma de definir un struct que herede los campos y las implementaciones de
+métodos de un struct padre sin usar una macro.
 
-However, if you’re used to having inheritance in your programming toolbox, you
-can use other solutions in Rust, depending on your reason for reaching for
-inheritance in the first place.
+Sin embargo, si estás acostumbrado a tener la herencia en tu caja de
+programación, puedes usar otras soluciones en Rust, dependiendo de tu razón
+para recurrir a la herencia en primer lugar.
 
-You would choose inheritance for two main reasons. One is for reuse of code:
-you can implement particular behavior for one type, and inheritance enables you
-to reuse that implementation for a different type. You can do this in a limited
-way in Rust code using default trait method implementations, which you saw in
-Listing 10-14 when we added a default implementation of the `summarize` method
-on the `Summary` trait. Any type implementing the `Summary` trait would have
-the `summarize` method available on it without any further code. This is
-similar to a parent class having an implementation of a method and an
-inheriting child class also having the implementation of the method. We can
-also override the default implementation of the `summarize` method when we
-implement the `Summary` trait, which is similar to a child class overriding the
-implementation of a method inherited from a parent class.
+Elegirías la herencia por dos razones principales. Una es reutilizar el código:
+puedes implementar un comportamiento particular para un tipo, y la herencia te
+permite reutilizar esa implementación para un tipo diferente. Puedes hacer esto
+de una manera limitada en el código Rust usando implementaciones de métodos
+predeterminados de un trait, que viste en el Listado 10-14 cuando agregamos una
+implementación predeterminada del método `summarize` en el trait `Summary`. 
+Cualquier tipo que implemente el trait `Summary` tendría el método `summarize` 
+disponible sin ningún código adicional. Esto es similar a una clase padre que 
+tiene una implementación de un método y una clase hija heredada que también 
+tiene la implementación del método. También podemos anular la implementación
+predeterminada del método `summarize` cuando implementamos el trait `Summary`,
+lo que es similar a una clase hija anulando la implementación de un método
+heredado de una clase padre.
 
-The other reason to use inheritance relates to the type system: to enable a
-child type to be used in the same places as the parent type. This is also
-called *polymorphism*, which means that you can substitute multiple objects for
-each other at runtime if they share certain characteristics.
+La otra razón para usar la herencia está relacionada con el sistema de tipos:
+permitir que un tipo hijo se use en los mismos lugares que el tipo padre. Esto
+es también llamado *polimorfismo*, lo que significa que puedes sustituir
+múltiples objetos entre sí en tiempo de ejecución si comparten ciertas
+características.
 
-> ### Polymorphism
+> ### Polimorfismo
 >
-> To many people, polymorphism is synonymous with inheritance. But it’s
-> actually a more general concept that refers to code that can work with data
-> of multiple types. For inheritance, those types are generally subclasses.
+> Para muchas personas, el polimorfismo es sinónimo de herencia. Pero en
+> realidad es un concepto más general que se refiere al código que puede
+> trabajar con datos de múltiples tipos. Para la herencia, esos tipos son
+> generalmente subclases.
 >
-> Rust instead uses generics to abstract over different possible types and
-> trait bounds to impose constraints on what those types must provide. This is
-> sometimes called *bounded parametric polymorphism*.
+> En cambio, Rust utiliza generics para abstraerse sobre diferentes tipos
+> posibles y los trait bounds para imponer restricciones sobre lo que
+> esos tipos deben proporcionar. Esto se llama a veces *polimorfismo paramétrico
+> acotado*.
 
-Inheritance has recently fallen out of favor as a programming design solution
-in many programming languages because it’s often at risk of sharing more code
-than necessary. Subclasses shouldn’t always share all characteristics of their
-parent class but will do so with inheritance. This can make a program’s design
-less flexible. It also introduces the possibility of calling methods on
-subclasses that don’t make sense or that cause errors because the methods don’t
-apply to the subclass. In addition, some languages will only allow single
-inheritance (meaning a subclass can only inherit from one class), further
-restricting the flexibility of a program’s design.
+En los últimos tiempos, la herencia ha perdido popularidad como solución de
+diseño de programas en muchos lenguajes de programación porque a menudo está en
+riesgo de compartir más código del necesario. Las subclases no siempre deben
+compartir todas las características de su clase padre, pero lo harán con la
+herencia. Esto puede hacer que el diseño de un programa sea menos flexible.
+También introduce la posibilidad de llamar a métodos en subclases que no tienen
+sentido o que causan errores porque los métodos no se aplican a la subclase.
+Además, algunos lenguajes solo permitirán una herencia única (lo que significa
+que una subclase solo puede heredar de una clase), lo que restringe aún más la
+flexibilidad del diseño de un programa.
 
-For these reasons, Rust takes the different approach of using trait objects
-instead of inheritance. Let’s look at how trait objects enable polymorphism in
+Por estas razones, Rust toma un enfoque diferente utilizando trait objects en
+lugar de herencia. Veamos cómo los trait objects permiten el polimorfismo en
 Rust.

--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -1,70 +1,78 @@
-## Using Trait Objects That Allow for Values of Different Types
+## Usando Trait Objects que permiten valores de diferentes tipos
 
-In Chapter 8, we mentioned that one limitation of vectors is that they can
-store elements of only one type. We created a workaround in Listing 8-9 where
-we defined a `SpreadsheetCell` enum that had variants to hold integers, floats,
-and text. This meant we could store different types of data in each cell and
-still have a vector that represented a row of cells. This is a perfectly good
-solution when our interchangeable items are a fixed set of types that we know
-when our code is compiled.
+En el capítulo 8, mencionamos que una limitación de los vectores es que pueden
+almacenar elementos de un solo tipo. Creamos una solución en el Listado 8-9
+donde definimos un enum `SpreadsheetCell` que tenía variantes para almacenar
+enteros, flotantes y texto. Esto significaba que podíamos almacenar diferentes
+tipos de datos en cada celda y aun así tener un vector que representara una
+fila de celdas. Esta es una solución perfectamente buena cuando nuestros
+elementos intercambiables son un conjunto fijo de tipos que conocemos cuando
+se compila nuestro código.
 
-However, sometimes we want our library user to be able to extend the set of
-types that are valid in a particular situation. To show how we might achieve
-this, we’ll create an example graphical user interface (GUI) tool that iterates
-through a list of items, calling a `draw` method on each one to draw it to the
-screen—a common technique for GUI tools. We’ll create a library crate called
-`gui` that contains the structure of a GUI library. This crate might include
-some types for people to use, such as `Button` or `TextField`. In addition,
-`gui` users will want to create their own types that can be drawn: for
-instance, one programmer might add an `Image` and another might add a
-`SelectBox`.
+Sin embargo, a veces queremos que los usuarios de nuestra biblioteca puedan
+ampliar el conjunto de tipos que pueden almacenar en una estructura de datos.
+Para mostrar cómo podríamos lograr esto, crearemos una herramienta de
+interfaz gráfica de usuario (GUI) de ejemplo que itera a través de una lista
+de elementos, llamando a un método `draw` en cada uno para dibujarlo en la
+pantalla, una técnica común para las herramientas de GUI. Crearemos una 
+caja de biblioteca llamada `gui` que contiene la estructura de una biblioteca
+GUI. Esta caja podría incluir algunos tipos para que las personas los usen,
+como `Button` o `TextField`. Además, los usuarios de `gui` querrán crear sus
+propios tipos que se puedan dibujar: por ejemplo, un programador podría
+agregar una `Image` y otro podría agregar un `SelectBox`.
 
-We won’t implement a fully fledged GUI library for this example but will show
-how the pieces would fit together. At the time of writing the library, we can’t
-know and define all the types other programmers might want to create. But we do
-know that `gui` needs to keep track of many values of different types, and it
-needs to call a `draw` method on each of these differently typed values. It
-doesn’t need to know exactly what will happen when we call the `draw` method,
-just that the value will have that method available for us to call.
+No implementaremos una biblioteca GUI completamente desarrollada para este
+ejemplo, pero mostraremos cómo encajarían las piezas. En el momento de
+escribir la biblioteca, no podemos conocer y definir todos los tipos que
+otros programadores podrían querer crear. Pero sí sabemos que `gui` necesita
+hacer un seguimiento de muchos valores de diferentes tipos, y necesita llamar
+a un método `draw` en cada uno de estos valores de diferentes tipos. No
+necesita saber exactamente qué sucederá cuando llamemos al método `draw`, solo
+que el valor tendrá ese método disponible para que lo llamemos.
 
-To do this in a language with inheritance, we might define a class named
-`Component` that has a method named `draw` on it. The other classes, such as
-`Button`, `Image`, and `SelectBox`, would inherit from `Component` and thus
-inherit the `draw` method. They could each override the `draw` method to define
-their custom behavior, but the framework could treat all of the types as if
-they were `Component` instances and call `draw` on them. But because Rust
-doesn’t have inheritance, we need another way to structure the `gui` library to
-allow users to extend it with new types.
+Para hacer esto en un lenguaje con herencia, podríamos definir una clase
+llamada `Component` que tenga un método llamado `draw` en ella. Las otras
+clases, como `Button`, `Image` y `SelectBox`, heredarían de `Component` y,
+por lo tanto, heredarían el método `draw`. Cada uno podría anular el método
+`draw` para definir su comportamiento personalizado, pero el marco podría
+tratar todos los tipos como si fueran instancias de `Component` y llamar a
+`draw` en ellos. Pero como Rust no tiene herencia, necesitamos otra forma de
+estructurar la biblioteca `gui` para permitir a los usuarios extenderla con
+nuevos tipos.
 
-### Defining a Trait for Common Behavior
+### Definir un Trait para un comportamiento común
 
-To implement the behavior we want `gui` to have, we’ll define a trait named
-`Draw` that will have one method named `draw`. Then we can define a vector that
-takes a *trait object*. A trait object points to both an instance of a type
-implementing our specified trait and a table used to look up trait methods on
-that type at runtime. We create a trait object by specifying some sort of
-pointer, such as a `&` reference or a `Box<T>` smart pointer, then the `dyn`
-keyword, and then specifying the relevant trait. (We’ll talk about the reason
-trait objects must use a pointer in Chapter 19 in the section [“Dynamically
-Sized Types and the `Sized` Trait.”][dynamically-sized]<!-- ignore -->) We can
-use trait objects in place of a generic or concrete type. Wherever we use a
-trait object, Rust’s type system will ensure at compile time that any value
-used in that context will implement the trait object’s trait. Consequently, we
-don’t need to know all the possible types at compile time.
+Para implementar el comportamiento que queremos que tenga `gui`, definiremos
+un trait llamado `Draw` que tendrá un método llamado `draw`. Luego podemos
+definir un vector que tome un *objeto de trait*. Un objeto de trait apunta
+tanto a una instancia de un tipo que implementa nuestro trait especificado
+como a una tabla utilizada para buscar métodos de trait en ese tipo en tiempo
+de ejecución. Creamos un objeto de trait especificando algún tipo de puntero,
+como una referencia `&` o un puntero inteligente `Box<T>`, luego la palabra
+clave `dyn` y luego especificando el trait relevante. (Hablaremos sobre la
+razón por la que los objetos de trait deben usar un puntero en el Capítulo 19
+en la sección [“Tipos de tamaño dinámico y el 
+trait `Sized`.”][dynamically-sized]<!-- ignore -->) Podemos usar objetos de 
+trait en lugar de un tipo genérico o concreto. Donde sea que usemos un objeto 
+de trait, el sistema de tipos de Rust se asegurará en tiempo de compilación que
+cualquier valor utilizado en ese contexto implemente el trait del objeto de 
+trait. En consecuencia, no necesitamos conocer todos los tipos posibles en 
+tiempo de compilación.
 
-We’ve mentioned that, in Rust, we refrain from calling structs and enums
-“objects” to distinguish them from other languages’ objects. In a struct or
-enum, the data in the struct fields and the behavior in `impl` blocks are
-separated, whereas in other languages, the data and behavior combined into one
-concept is often labeled an object. However, trait objects *are* more like
-objects in other languages in the sense that they combine data and behavior.
-But trait objects differ from traditional objects in that we can’t add data to
-a trait object. Trait objects aren’t as generally useful as objects in other
-languages: their specific purpose is to allow abstraction across common
-behavior.
+Hemos mencionado que, en Rust, nos abstenemos de llamar a los structs y enums
+“objetos” para distinguirlos de los objetos de otros lenguajes. En un struct o
+enum, los datos en los campos del struct y el comportamiento en los bloques
+`impl` están separados, mientras que en otros lenguajes, los datos y el
+comportamiento combinados en un solo concepto a menudo se etiquetan como un
+objeto. Sin embargo, los objetos de trait son más como objetos en otros
+lenguajes en el sentido de que combinan datos y comportamiento. Pero los
+objetos de trait difieren de los objetos tradicionales en que no podemos
+agregar datos a un objeto de trait. Los objetos de trait no son tan útiles en
+general como los objetos en otros lenguajes: su propósito específico es
+permitir la abstracción a través del comportamiento común.
 
-Listing 17-3 shows how to define a trait named `Draw` with one method named
-`draw`:
+El Listado 17-3 muestra cómo definir un trait llamado `Draw` con un método
+llamado `draw`:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -72,13 +80,14 @@ Listing 17-3 shows how to define a trait named `Draw` with one method named
 {{#rustdoc_include ../listings/ch17-oop/listing-17-03/src/lib.rs}}
 ```
 
-<span class="caption">Listing 17-3: Definition of the `Draw` trait</span>
+<span class="caption">Listing 17-3: Definición del trait `Draw`</span>
 
-This syntax should look familiar from our discussions on how to define traits
-in Chapter 10. Next comes some new syntax: Listing 17-4 defines a struct named
-`Screen` that holds a vector named `components`. This vector is of type
-`Box<dyn Draw>`, which is a trait object; it’s a stand-in for any type inside
-a `Box` that implements the `Draw` trait.
+Esta sintaxis debería verse familiar de nuestras discusiones sobre cómo
+definir traits en el Capítulo 10. A continuación viene una sintaxis nueva: el
+Listado 17-4 define un struct llamado `Screen` que contiene un vector llamado
+`components`. Este vector es de tipo `Box<dyn Draw>`, que es un objeto de
+trait; es un sustituto de cualquier tipo dentro de una `Box` que implementa el
+trait `Draw`.
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -86,12 +95,13 @@ a `Box` that implements the `Draw` trait.
 {{#rustdoc_include ../listings/ch17-oop/listing-17-04/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-4: Definition of the `Screen` struct with a
-`components` field holding a vector of trait objects that implement the `Draw`
-trait</span>
+<span class="caption">Listing 17-4: Definición del struct `Screen` con un campo
+`components` que contiene un vector de trait objects que implementan el trait
+`Draw`</span>
 
-On the `Screen` struct, we’ll define a method named `run` that will call the
-`draw` method on each of its `components`, as shown in Listing 17-5:
+En el struct `Screen` hemos definido un método llamado `run` que llamará al
+método `draw` en cada uno de sus `components`, como se muestra en el Listado
+17-5:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -99,15 +109,16 @@ On the `Screen` struct, we’ll define a method named `run` that will call the
 {{#rustdoc_include ../listings/ch17-oop/listing-17-05/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-5: A `run` method on `Screen` that calls the
-`draw` method on each component</span>
+<span class="caption">Listing 17-5: Un método `run` en `Screen` que llama al
+método `draw` en cada componente</span>
 
-This works differently from defining a struct that uses a generic type
-parameter with trait bounds. A generic type parameter can only be substituted
-with one concrete type at a time, whereas trait objects allow for multiple
-concrete types to fill in for the trait object at runtime. For example, we
-could have defined the `Screen` struct using a generic type and a trait bound
-as in Listing 17-6:
+Esto funciona de manera diferente a la definición de un struct que usa un
+parámetro de tipo generic con trait bound. Un parámetro de tipo generic
+solo se puede sustituir con un tipo concreto a la vez, mientras que los
+trait objects permiten que varios tipos concretos llenen el trait object
+en tiempo de ejecución. Por ejemplo, podríamos haber definido el struct
+`Screen` usando un parámetro de tipo generic y un trait bound como en el
+Listado 17-6:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -115,26 +126,28 @@ as in Listing 17-6:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-06/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-6: An alternate implementation of the `Screen`
-struct and its `run` method using generics and trait bounds</span>
+<span class="caption">Listing 17-6: Una implementación alternativa del struct
+`Screen` y su método `run` usando generics y trait bounds</span>
 
-This restricts us to a `Screen` instance that has a list of components all of
-type `Button` or all of type `TextField`. If you’ll only ever have homogeneous
-collections, using generics and trait bounds is preferable because the
-definitions will be monomorphized at compile time to use the concrete types.
+Esto nos restringe a una instancia de `Screen` que tiene una lista de
+componentes de tipo `Button` o de tipo `TextField`. Si solo tendrá
+colecciones homogéneas, usar generics y trait bounds es preferible porque las
+definiciones se monomorfizarán en tiempo de compilación para usar los tipos
+concretos.
 
-On the other hand, with the method using trait objects, one `Screen` instance
-can hold a `Vec<T>` that contains a `Box<Button>` as well as a
-`Box<TextField>`. Let’s look at how this works, and then we’ll talk about the
-runtime performance implications.
+Por otro lado, con el método que utiliza trait objects, una instancia de
+`Screen` puede contener un `Vec<T>` que contiene una `Box<Button>` así como
+una `Box<TextField>`. Veamos cómo funciona esto, y luego hablaremos sobre las
+implicaciones de rendimiento en tiempo de ejecución.
 
-### Implementing the Trait
+### Implementando el trait
 
-Now we’ll add some types that implement the `Draw` trait. We’ll provide the
-`Button` type. Again, actually implementing a GUI library is beyond the scope
-of this book, so the `draw` method won’t have any useful implementation in its
-body. To imagine what the implementation might look like, a `Button` struct
-might have fields for `width`, `height`, and `label`, as shown in Listing 17-7:
+Ahora agregaremos algunos tipos que implementen el trait `Draw`. 
+Proporcionaremos el tipo `Button`. Nuevamente, implementar una biblioteca GUI
+está más allá del alcance de este libro, por lo que el método `draw` no tendrá
+ninguna implementación útil en su cuerpo. Para imaginar cómo podría ser la
+implementación, un struct `Button` podría tener campos para `width`, `height`
+y `label`, como se muestra en el Listado 17-7:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -142,22 +155,24 @@ might have fields for `width`, `height`, and `label`, as shown in Listing 17-7:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-07/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-7: A `Button` struct that implements the
-`Draw` trait</span>
+<span class="caption">Listing 17-7: Un `Button` que implementa el trait
+`Draw`</span>
 
-The `width`, `height`, and `label` fields on `Button` will differ from the
-fields on other components; for example, a `TextField` type might have those
-same fields plus a `placeholder` field. Each of the types we want to draw on
-the screen will implement the `Draw` trait but will use different code in the
-`draw` method to define how to draw that particular type, as `Button` has here
-(without the actual GUI code, as mentioned). The `Button` type, for instance,
-might have an additional `impl` block containing methods related to what
-happens when a user clicks the button. These kinds of methods won’t apply to
-types like `TextField`.
+Los campos `width`, `height` y `label` en `Button` serán diferentes de los
+campos en otros componentes; por ejemplo, un tipo `TextField` podría tener
+esos mismos campos más un campo `placeholder`. Cada uno de los tipos que
+queremos dibujar en la pantalla implementará el trait `Draw` pero usará
+código diferente en el método `draw` para definir cómo dibujar ese tipo
+particular, como lo hace `Button` aquí (sin el código GUI real, como se
+mencionó). El tipo `Button`, por ejemplo, podría tener un bloque `impl`
+adicional que contenga métodos relacionados con lo que sucede cuando un
+usuario hace clic en el botón. Este tipo de métodos no se aplicarán a tipos
+como `TextField`.
 
-If someone using our library decides to implement a `SelectBox` struct that has
-`width`, `height`, and `options` fields, they implement the `Draw` trait on the
-`SelectBox` type as well, as shown in Listing 17-8:
+Si alguien que utiliza nuestra biblioteca decide implementar un struct
+`SelectBox` que tiene campos `width`, `height` y `options`, también
+implementará el trait `Draw` en el tipo `SelectBox`, como se muestra en el
+Listado 17-8:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -165,14 +180,15 @@ If someone using our library decides to implement a `SelectBox` struct that has
 {{#rustdoc_include ../listings/ch17-oop/listing-17-08/src/main.rs:here}}
 ```
 
-<span class="caption">Listing 17-8: Another crate using `gui` and implementing
-the `Draw` trait on a `SelectBox` struct</span>
+<span class="caption">Listing 17-8: Otro crate usando `gui` e implementando
+el trait `Draw` en un struct `SelectBox`</span>
 
-Our library’s user can now write their `main` function to create a `Screen`
-instance. To the `Screen` instance, they can add a `SelectBox` and a `Button`
-by putting each in a `Box<T>` to become a trait object. They can then call the
-`run` method on the `Screen` instance, which will call `draw` on each of the
-components. Listing 17-9 shows this implementation:
+El usuario de nuestra biblioteca ahora puede escribir su función `main` para
+crear una instancia de `Screen`. A la instancia de `Screen`, pueden agregar
+un `SelectBox` y un `Button` colocando cada uno en una `Box<T>` para
+convertirse en un trait object. Luego pueden llamar al método `run` en la
+instancia de `Screen`, que llamará a `draw` en cada uno de los componentes.
+El Listado 17-9 muestra esta implementación:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -180,33 +196,34 @@ components. Listing 17-9 shows this implementation:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-09/src/main.rs:here}}
 ```
 
-<span class="caption">Listing 17-9: Using trait objects to store values of
-different types that implement the same trait</span>
+<span class="caption">Listing 17-9: Usando trait objects para almacenar valores 
+de diferentes tipos que implementan el mismo trait</span>
 
-When we wrote the library, we didn’t know that someone might add the
-`SelectBox` type, but our `Screen` implementation was able to operate on the
-new type and draw it because `SelectBox` implements the `Draw` trait, which
-means it implements the `draw` method.
+Cuando escribimos la biblioteca, no sabíamos que alguien podría agregar el tipo
+`SelectBox`, pero nuestra implementación de `Screen` pudo operar en el nuevo
+tipo y dibujarlo porque `SelectBox` implementa el trait `Draw`, lo que significa
+que implementa el método `draw`.
 
-This concept—of being concerned only with the messages a value responds to
-rather than the value’s concrete type—is similar to the concept of *duck
-typing* in dynamically typed languages: if it walks like a duck and quacks
-like a duck, then it must be a duck! In the implementation of `run` on `Screen`
-in Listing 17-5, `run` doesn’t need to know what the concrete type of each
-component is. It doesn’t check whether a component is an instance of a `Button`
-or a `SelectBox`, it just calls the `draw` method on the component. By
-specifying `Box<dyn Draw>` as the type of the values in the `components`
-vector, we’ve defined `Screen` to need values that we can call the `draw`
-method on.
+Este concepto, de preocuparnos solo por los mensajes a los que responde un valor
+en lugar del tipo concreto del valor, es similar al concepto de *duck typing* en
+lenguajes de tipado dinámico: si camina como un pato y grazna como un pato,
+¡entonces debe ser un pato! En la implementación de `run` en `Screen` en el
+Listado 17-5, `run` no necesita saber cuál es el tipo concreto de cada
+componente. No verifica si un componente es una instancia de un `Button` o de
+un `SelectBox`, simplemente llama al método `draw` en el componente. Al
+especificar `Box<dyn Draw>` como el tipo de los valores en el vector
+`components`, hemos definido que `Screen` necesita valores a los que podamos
+llamar el método `draw`.
 
-The advantage of using trait objects and Rust’s type system to write code
-similar to code using duck typing is that we never have to check whether a
-value implements a particular method at runtime or worry about getting errors
-if a value doesn’t implement a method but we call it anyway. Rust won’t compile
-our code if the values don’t implement the traits that the trait objects need.
+La ventaja de utilizar trait objects y el sistema de tipos de Rust para escribir
+código similar al código que utiliza duck typing es que nunca tenemos que
+verificar si un valor implementa un método en particular en tiempo de ejecución
+o preocuparnos por obtener errores si un valor no implementa un método, pero lo
+llamamos de todos modos. Rust no compilará nuestro código si los valores no
+implementan los traits que necesitan los trait objects.
 
-For example, Listing 17-10 shows what happens if we try to create a `Screen`
-with a `String` as a component:
+Por ejemplo, el Listado 17-10 muestra lo que sucede si intentamos crear una
+`Screen` con un `String` como componente:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -214,42 +231,43 @@ with a `String` as a component:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-10/src/main.rs}}
 ```
 
-<span class="caption">Listing 17-10: Attempting to use a type that doesn’t
-implement the trait object’s trait</span>
+<span class="caption">Listing 17-10: Intentando utilizar un tipo que no
+implementa the trait del trait object</span>
 
-We’ll get this error because `String` doesn’t implement the `Draw` trait:
+Obtendremos este error porque `String` no implementa el trait `Draw`:
 
 ```console
 {{#include ../listings/ch17-oop/listing-17-10/output.txt}}
 ```
 
-This error lets us know that either we’re passing something to `Screen` we
-didn’t mean to pass and so should pass a different type or we should implement
-`Draw` on `String` so that `Screen` is able to call `draw` on it.
+Este error nos indica que o bien estamos pasando algo a `Screen` que no
+queríamos pasar y, por lo tanto, deberíamos pasar un tipo diferente o deberíamos
+implementar `Draw` en `String` para que `Screen` pueda llamar a `draw` en él.
 
-### Trait Objects Perform Dynamic Dispatch
+### Los trait objects realizan *dynamic dispatch*
 
-Recall in the [“Performance of Code Using
-Generics”][performance-of-code-using-generics]<!-- ignore --> section in
-Chapter 10 our discussion on the monomorphization process performed by the
-compiler when we use trait bounds on generics: the compiler generates
-nongeneric implementations of functions and methods for each concrete type that
-we use in place of a generic type parameter. The code that results from
-monomorphization is doing *static dispatch*, which is when the compiler knows
-what method you’re calling at compile time. This is opposed to *dynamic
-dispatch*, which is when the compiler can’t tell at compile time which method
-you’re calling. In dynamic dispatch cases, the compiler emits code that at
-runtime will figure out which method to call.
+Recuerda que en la sección [“Performance of Code Using
+Generics”][performance-of-code-using-generics]<!-- ignore --> del Capítulo 10
+hablamos sobre el proceso de monomorfización que realiza el compilador cuando
+usamos *trait bounds* en los genéricos: el compilador genera implementaciones
+no genéricas de funciones y métodos para cada tipo concreto que usamos en lugar
+de un parámetro de tipo genérico. El código que resulta de la monomorfización
+está realizando *static dispatch*, que es cuando el compilador sabe qué método
+estás llamando en tiempo de compilación. Esto se opone al *dynamic dispatch*,
+que es cuando el compilador no puede decir en tiempo de compilación qué método
+estás llamando. En los casos de dynamic dispatch, el compilador emite código que
+en tiempo de ejecución determinará qué método llamar.
 
-When we use trait objects, Rust must use dynamic dispatch. The compiler doesn’t
-know all the types that might be used with the code that’s using trait objects,
-so it doesn’t know which method implemented on which type to call. Instead, at
-runtime, Rust uses the pointers inside the trait object to know which method to
-call. This lookup incurs a runtime cost that doesn’t occur with static
-dispatch. Dynamic dispatch also prevents the compiler from choosing to inline a
-method’s code, which in turn prevents some optimizations. However, we did get
-extra flexibility in the code that we wrote in Listing 17-5 and were able to
-support in Listing 17-9, so it’s a trade-off to consider.
+Cuando usamos trait objects, Rust debe usar dynamic dispatch. El compilador no
+conoce todos los tipos que podrían usarse con el código que está llamando a
+trait objects, por lo que no sabe qué método implementado en qué tipo llamar. En
+cambio, en tiempo de ejecución, Rust usa los punteros dentro del trait object
+para saber qué método llamar. Esta búsqueda incurre en un costo de tiempo de
+ejecución que no ocurre con el static dispatch. Dynamic dispatch también evita
+que el compilador elija la opción de *inline* del código de un método, lo que a
+su vez evita algunas optimizaciones. Sin embargo, obtuvimos flexibilidad
+adicional en el código que escribimos en el Listado 17-5 y pudimos admitir en
+el Listado 17-9, por lo que es un compromiso a considerar.
 
 [performance-of-code-using-generics]:
 ch10-01-syntax.html#performance-of-code-using-generics

--- a/src/ch17-03-oo-design-patterns.md
+++ b/src/ch17-03-oo-design-patterns.md
@@ -546,7 +546,7 @@ fortalezas de Rust, pero es una opción disponible.
 
 A continuación, veremos los patterns, que son otra de las características de 
 Rust que permiten mucha flexibilidad. Hemos visto brevemente los patterns a lo
-largo del libro, pero aún no hemos visto su capacidad total. ¡Vamos allá!
+largo del libro, pero aún no hemos visto su capacidad total. ¡Vamos allá! 
 
 [more-info-than-rustc]: ch09-03-to-panic-or-not-to-panic.html#cases-in-which-you-have-more-information-than-the-compiler
 [macros]: ch19-06-macros.html#macros

--- a/src/ch17-03-oo-design-patterns.md
+++ b/src/ch17-03-oo-design-patterns.md
@@ -1,44 +1,49 @@
-## Implementing an Object-Oriented Design Pattern
+## Implementando un patrón de diseño orientado a objetos
 
-The *state pattern* is an object-oriented design pattern. The crux of the
-pattern is that we define a set of states a value can have internally. The
-states are represented by a set of *state objects*, and the value’s behavior
-changes based on its state. We’re going to work through an example of a blog
-post struct that has a field to hold its state, which will be a state object
-from the set "draft", "review", or "published".
+El *state pattern* es un patrón de diseño orientado a objetos. La esencia del 
+patrón es que definimos un conjunto de estados que un valor puede tener 
+internamente. Los estados están representados por un conjunto de *state 
+objects*, y el comportamiento del valor cambia según su estado. Vamos a
+trabajar a través de un ejemplo de un struct de publicación de blog que
+tiene un campo para mantener su estado, que será un state object del conjunto
+"borrador", "revisión" o "publicado".
 
-The state objects share functionality: in Rust, of course, we use structs and
-traits rather than objects and inheritance. Each state object is responsible
-for its own behavior and for governing when it should change into another
-state. The value that holds a state object knows nothing about the different
-behavior of the states or when to transition between states.
+Los state objects comparten funcionalidad: en Rust, por supuesto, usamos
+structs y traits en lugar de objetos y herencia. Cada state object es
+responsable de su propio comportamiento y de gobernar cuándo debe cambiar a
+otro estado. El valor que contiene un state object no sabe nada sobre el
+comportamiento diferente de los estados o cuándo hacer la transición entre
+estados.
 
-The advantage of using the state pattern is that, when the business
-requirements of the program change, we won’t need to change the code of the
-value holding the state or the code that uses the value. We’ll only need to
-update the code inside one of the state objects to change its rules or perhaps
-add more state objects.
+La ventaja de usar el state pattern es que, cuando los requisitos comerciales
+del programa cambian, no necesitaremos cambiar el código del valor que
+contiene el estado o el código que usa el valor. Solo necesitaremos actualizar
+el código dentro de uno de los state objects para cambiar sus reglas o quizás
+agregar más state objects.
 
-First, we’re going to implement the state pattern in a more traditional
-object-oriented way, then we’ll use an approach that’s a bit more natural in
-Rust. Let’s dig in to incrementally implementing a blog post workflow using the
-state pattern.
+Primero, vamos a implementar el state pattern de una manera más tradicional
+orientada a objetos, luego usaremos un enfoque que es un poco más natural en
+Rust. Vamos a profundizar en la implementación incremental de un flujo de
+trabajo de publicación de blog usando el state pattern.
 
-The final functionality will look like this:
+La funcionalidad final se verá así:
 
-1. A blog post starts as an empty draft.
-2. When the draft is done, a review of the post is requested.
-3. When the post is approved, it gets published.
-4. Only published blog posts return content to print, so unapproved posts can’t
-   accidentally be published.
+1. Un post de blog que comienza como un borrador vacío.
+2. Cuando se completa el borrador, se solicita una revisión de la publicación.
+3. Cuando se aprueba la publicación, se publica.
+4. Solo las publicaciones de blog publicadas devuelven contenido para imprimir,
+   por lo que las publicaciones no aprobadas no pueden publicarse
+   accidentalmente.
 
-Any other changes attempted on a post should have no effect. For example, if we
-try to approve a draft blog post before we’ve requested a review, the post
-should remain an unpublished draft.
+Cualquier otro cambio que se intente realizar en una publicación no debería
+tener ningún efecto. Por ejemplo, si intentamos aprobar un borrador de blog
+antes de haber solicitado una revisión, la publicación debería seguir siendo
+un borrador no publicado.
 
-Listing 17-11 shows this workflow in code form: this is an example usage of the
-API we’ll implement in a library crate named `blog`. This won’t compile yet
-because we haven’t implemented the `blog` crate.
+El Listado 17-11 muestra este flujo de trabajo en forma de código: este es un
+ejemplo de uso de la API que implementaremos en una crate de biblioteca
+llamada `blog`. Esto aún no se compilará porque no hemos implementado el crate
+de biblioteca `blog`.
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -46,43 +51,46 @@ because we haven’t implemented the `blog` crate.
 {{#rustdoc_include ../listings/ch17-oop/listing-17-11/src/main.rs:all}}
 ```
 
-<span class="caption">Listing 17-11: Code that demonstrates the desired
-behavior we want our `blog` crate to have</span>
+<span class="caption">Listing 17-11: Código que demuestra el comportamiento
+deseado que queremos que tenga nuestro crate `blog`</span>
 
-We want to allow the user to create a new draft blog post with `Post::new`. We
-want to allow text to be added to the blog post. If we try to get the post’s
-content immediately, before approval, we shouldn’t get any text because the
-post is still a draft. We’ve added `assert_eq!` in the code for demonstration
-purposes. An excellent unit test for this would be to assert that a draft blog
-post returns an empty string from the `content` method, but we’re not going to
-write tests for this example.
+Queremos permitir que el usuario cree una nueva publicación de blog en borrador
+con `Post::new`. Queremos permitir que se agregue texto a la publicación del
+blog. Si intentamos obtener el contenido de la publicación inmediatamente,
+antes de la aprobación, no deberíamos obtener ningún texto porque la publicación
+sigue siendo un borrador. Hemos agregado `assert_eq!` en el código con fines de
+demostración. Una excelente prueba unitaria para esto sería afirmar que una
+publicación de blog en borrador devuelve un string vacío del método `content`,
+pero no vamos a escribir pruebas para este ejemplo.
 
-Next, we want to enable a request for a review of the post, and we want
-`content` to return an empty string while waiting for the review. When the post
-receives approval, it should get published, meaning the text of the post will
-be returned when `content` is called.
+A continuación, queremos permitir una solicitud de revisión de la publicación
+y queremos que `content` devuelva un string vacío mientras espera la revisión.
+Cuando la publicación reciba la aprobación, debería publicarse, lo que significa
+que el texto de la publicación se devolverá cuando se llame a `content`.
 
-Notice that the only type we’re interacting with from the crate is the `Post`
-type. This type will use the state pattern and will hold a value that will be
-one of three state objects representing the various states a post can be
-in—draft, waiting for review, or published. Changing from one state to another
-will be managed internally within the `Post` type. The states change in
-response to the methods called by our library’s users on the `Post` instance,
-but they don’t have to manage the state changes directly. Also, users can’t
-make a mistake with the states, like publishing a post before it’s reviewed.
+Observa que el único tipo con el que estamos interactuando desde el crate es
+el tipo `Post`. Este tipo utilizará el state pattern y contendrá un valor que
+será uno de los tres state objects que representan los diversos estados
+en los que puede estar una publicación: borrador, esperando revisión o
+publicado. El cambio de un estado a otro se administrará internamente dentro
+del tipo `Post`. Los estados cambian en respuesta a los métodos llamados por
+los usuarios de nuestra biblioteca en la instancia `Post`, pero no tienen que
+administrar los cambios de estado directamente. Además, los usuarios no pueden
+cometer un error con los estados, como publicar una publicación antes de que
+se revise.
 
-### Defining `Post` and Creating a New Instance in the Draft State
+### Definiendo `Post` y creando una nueva instancia en el estado de borrador
 
-Let’s get started on the implementation of the library! We know we need a
-public `Post` struct that holds some content, so we’ll start with the
-definition of the struct and an associated public `new` function to create an
-instance of `Post`, as shown in Listing 17-12. We’ll also make a private
-`State` trait that will define the behavior that all state objects for a `Post`
-must have.
+¡Comencemos con la implementación de la biblioteca! Sabemos que necesitamos
+un struct `Post` público que contenga algún contenido, por lo que comenzaremos
+con la definición del struct y una función pública `new` asociada para crear
+una instancia de `Post`, como se muestra en el Listado 17-12. También haremos
+un trait privado `State` que definirá el comportamiento que todos los objetos
+de estado para un `Post` deben tener.
 
-Then `Post` will hold a trait object of `Box<dyn State>` inside an `Option<T>`
-in a private field named `state` to hold the state object. You’ll see why the
-`Option<T>` is necessary in a bit.
+Luego, `Post` contendrá un trait object de `Box<dyn State>` dentro de un campo
+privado llamado `state` para mantener el state object. Verás por qué
+`Option<T>` es necesario en un momento.
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -90,32 +98,32 @@ in a private field named `state` to hold the state object. You’ll see why the
 {{#rustdoc_include ../listings/ch17-oop/listing-17-12/src/lib.rs}}
 ```
 
-<span class="caption">Listing 17-12: Definition of a `Post` struct and a `new`
-function that creates a new `Post` instance, a `State` trait, and a `Draft`
-struct</span>
+<span class="caption">Listing 17-12: Definición de un struct `Post` y una 
+función `new` que crea una nueva instancia de `Post`, un trait `State`, y un 
+struct `Draft`</span>
 
-The `State` trait defines the behavior shared by different post states. The
-state objects are `Draft`, `PendingReview`, and `Published`, and they will all
-implement the `State` trait. For now, the trait doesn’t have any methods, and
-we’ll start by defining just the `Draft` state because that is the state we
-want a post to start in.
+El trait `State` define el comportamiento compartido por los diferentes estados
+de una publicación. Los state objects son `Draft`, `PendingReview` y
+`Published`, y todos implementarán el trait `State`. Por ahora, el trait no
+tiene ningún método, y comenzaremos definiendo solo el estado `Draft` porque
+ese es el estado en el que queremos que comience una publicación.
 
-When we create a new `Post`, we set its `state` field to a `Some` value that
-holds a `Box`. This `Box` points to a new instance of the `Draft` struct.
-This ensures whenever we create a new instance of `Post`, it will start out as
-a draft. Because the `state` field of `Post` is private, there is no way to
-create a `Post` in any other state! In the `Post::new` function, we set the
-`content` field to a new, empty `String`.
+Cuando creamos un nuevo `Post`, estableceremos su campo `state` como un valor
+`Some` que contiene un `Box` que apunta a una nueva instancia del struct
+`Draft`. Esto asegura que cada vez que creemos una nueva instancia de `Post`,
+comenzará como un borrador. Debido a que el campo `state` de `Post` es privado,
+¡no hay forma de crear un `Post` en ningún otro estado! En la función 
+`Post::new`, establecemos el campo `content` en un nuevo `String` vacío.
 
-### Storing the Text of the Post Content
+### Almacenando el texto del contenido del post
 
-We saw in Listing 17-11 that we want to be able to call a method named
-`add_text` and pass it a `&str` that is then added as the text content of the
-blog post. We implement this as a method, rather than exposing the `content`
-field as `pub`, so that later we can implement a method that will control how
-the `content` field’s data is read. The `add_text` method is pretty
-straightforward, so let’s add the implementation in Listing 17-13 to the `impl
-Post` block:
+Vimos en el Listado 17-11 que queremos poder llamar a un método llamado 
+`add_text` y pasarle un `&str` que luego se agregará como el contenido de texto
+de la publicación del blog. Implementaremos esto como un método, en lugar de
+exponer el campo `content` como `pub`, para que más tarde podamos implementar
+un método que controlará cómo se lee el campo `content`. El método `add_text`
+es bastante sencillo, así que agreguemos la implementación en el Listado 17-13
+al bloque `impl Post`:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -123,27 +131,29 @@ Post` block:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-13/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-13: Implementing the `add_text` method to add
-text to a post’s `content`</span>
+<span class="caption">Listing 17-13: Implementando el método `add_text` para
+agregar texto al campo `content` de una publicación</span>
 
-The `add_text` method takes a mutable reference to `self`, because we’re
-changing the `Post` instance that we’re calling `add_text` on. We then call
-`push_str` on the `String` in `content` and pass the `text` argument to add to
-the saved `content`. This behavior doesn’t depend on the state the post is in,
-so it’s not part of the state pattern. The `add_text` method doesn’t interact
-with the `state` field at all, but it is part of the behavior we want to
-support.
+El método `add_text` toma una referencia mutable a `self` porque estamos
+cambiando la instancia de `Post` en la que estamos llamando `add_text`. Luego
+llamamos a `push_str` en el `String` en `content` y pasamos el argumento `text`
+para agregar al `content` guardado. Este comportamiento no depende del estado
+en el que se encuentre la publicación, por lo que no es parte del state pattern.
+El método `add_text` no interactúa con el campo `state` en absoluto, pero es
+parte del comportamiento que queremos admitir.
 
-### Ensuring the Content of a Draft Post Is Empty
+### Asegurando que el contenido de un post en borrador esté vacío
 
-Even after we’ve called `add_text` and added some content to our post, we still
-want the `content` method to return an empty string slice because the post is
-still in the draft state, as shown on line 7 of Listing 17-11. For now, let’s
-implement the `content` method with the simplest thing that will fulfill this
-requirement: always returning an empty string slice. We’ll change this later
-once we implement the ability to change a post’s state so it can be published.
-So far, posts can only be in the draft state, so the post content should always
-be empty. Listing 17-14 shows this placeholder implementation:
+Incluso después de que hayamos llamado `add_text` y agregado algún contenido a
+nuestra publicación, todavía queremos que el método `content` devuelva un slice
+de string vacío porque la publicación todavía está en el estado de borrador,
+como se muestra en la línea 7 del Listado 17-11. Por ahora, implementemos el
+método `content` con lo más simple que cumplirá con este requisito: siempre
+devolver un string slice vacío. Lo cambiaremos más tarde una vez que
+implementemos la capacidad de cambiar el estado de una publicación para que
+pueda publicarse. Hasta ahora, las publicaciones solo pueden estar en el estado
+de borrador, por lo que el contenido de la publicación siempre debe estar
+vacío. El Listado 17-14 muestra esta implementación de marcador de posición:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -151,16 +161,18 @@ be empty. Listing 17-14 shows this placeholder implementation:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-14/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-14: Adding a placeholder implementation for
-the `content` method on `Post` that always returns an empty string slice</span>
+<span class="caption">Listing 17-14: Agregando una implementación provisional
+para el método `content` en `Post` que siempre devuelve un string slice vacío
+</span>
 
-With this added `content` method, everything in Listing 17-11 up to line 7
-works as intended.
+Con este método `content` añadido, todo en el Listado 17-11 hasta la línea 7
+funciona como se pretendía.
 
-### Requesting a Review of the Post Changes Its State
+### Solicitar una revisión de los cambios de publicación de su estado
 
-Next, we need to add functionality to request a review of a post, which should
-change its state from `Draft` to `PendingReview`. Listing 17-15 shows this code:
+A continuación, necesitamos agregar funcionalidad para solicitar una revisión
+de una publicación, lo que debería cambiar su estado de `Draft` a
+`PendingReview`. El Listado 17-15 muestra este código:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -168,59 +180,61 @@ change its state from `Draft` to `PendingReview`. Listing 17-15 shows this code:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-15/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-15: Implementing `request_review` methods on
-`Post` and the `State` trait</span>
+<span class="caption">Listing 17-15: Implementando los métodos `request_review`
+en `Post` y el trait `State`</span>
 
-We give `Post` a public method named `request_review` that will take a mutable
-reference to `self`. Then we call an internal `request_review` method on the
-current state of `Post`, and this second `request_review` method consumes the
-current state and returns a new state.
+Agregamos un método público llamado `request_review` a `Post` que toma una
+referencia mutable a `self`. Luego llamamos a un método interno `request_review`
+en el estado actual de `Post`, y este segundo método `request_review` consume
+el estado actual y devuelve un nuevo estado.
 
-We add the `request_review` method to the `State` trait; all types that
-implement the trait will now need to implement the `request_review` method.
-Note that rather than having `self`, `&self`, or `&mut self` as the first
-parameter of the method, we have `self: Box<Self>`. This syntax means the
-method is only valid when called on a `Box` holding the type. This syntax takes
-ownership of `Box<Self>`, invalidating the old state so the state value of the
-`Post` can transform into a new state.
+Agregamos el método `request_review` al trait `State`; todos los tipos que
+implementan el trait ahora deberán implementar el método `request_review`.
+Tenga en cuenta que en lugar de tener `self`, `&self` o `&mut self` como el
+primer parámetro del método, tenemos `self: Box<Self>`. Esta sintaxis significa
+que el método solo es válido cuando se llama en un `Box` que contiene el tipo.
+Esta sintaxis toma posesión de `Box<Self>`, invalidando el estado anterior para
+que el valor de estado de `Post` pueda transformarse en un nuevo estado.
 
-To consume the old state, the `request_review` method needs to take ownership
-of the state value. This is where the `Option` in the `state` field of `Post`
-comes in: we call the `take` method to take the `Some` value out of the `state`
-field and leave a `None` in its place, because Rust doesn’t let us have
-unpopulated fields in structs. This lets us move the `state` value out of
-`Post` rather than borrowing it. Then we’ll set the post’s `state` value to the
-result of this operation.
+Para consumir el antiguo estado, el método `request_review` debe tomar 
+ownership del valor de estado. Aquí es donde entra en juego la `Option` en el
+campo `state` de `Post`: llamamos al método `take` para sacar el valor `Some`
+del campo `state` y dejar un `None` en su lugar, porque Rust no nos permite
+tener campos no poblados en los structs. Esto nos permite mover el valor
+`state` fuera de `Post` en lugar de pedir borrowing. Luego estableceremos el
+valor `state` de la publicación en el resultado de esta operación.
 
-We need to set `state` to `None` temporarily rather than setting it directly
-with code like `self.state = self.state.request_review();` to get ownership of
-the `state` value. This ensures `Post` can’t use the old `state` value after
-we’ve transformed it into a new state.
+Necesitamos establecer `state` como `None` temporalmente en lugar de 
+establecerlo directamente con código como 
+`self.state = self.state.request_review();` para obtener la propiedad del
+valor `state`. Esto asegura que `Post` no pueda usar el valor `state` antiguo
+después de que lo hayamos transformado en un nuevo estado.
 
-The `request_review` method on `Draft` returns a new, boxed instance of a new
-`PendingReview` struct, which represents the state when a post is waiting for a
-review. The `PendingReview` struct also implements the `request_review` method
-but doesn’t do any transformations. Rather, it returns itself, because when we
-request a review on a post already in the `PendingReview` state, it should stay
-in the `PendingReview` state.
+El método `request_review` en `Draft` devuelve una nueva instancia de un nuevo 
+struct llamado `PendingReview`, que representa el estado cuando un post está 
+esperando una revisión. El struct `PendingReview` también implementa
+el método `request_review`, pero no hace ninguna transformación. En cambio,
+devuelve a sí mismo, porque cuando solicitamos una revisión en una publicación
+que ya está en el estado `PendingReview`, debe permanecer en el estado
+`PendingReview`.
 
-Now we can start seeing the advantages of the state pattern: the
-`request_review` method on `Post` is the same no matter its `state` value. Each
-state is responsible for its own rules.
+Ahora podemos comenzar a ver las ventajas del state pattern: el método 
+`request_review` en `Post` es el mismo sin importar su valor `state`. Cada
+estado es responsable de sus propias reglas.
 
-We’ll leave the `content` method on `Post` as is, returning an empty string
-slice. We can now have a `Post` in the `PendingReview` state as well as in the
-`Draft` state, but we want the same behavior in the `PendingReview` state.
-Listing 17-11 now works up to line 10!
+Dejaremos el método `content` en `Post` tal como está, devolviendo un string
+slice vacío. Ahora podemos tener un `Post` en el estado `PendingReview` así
+como en el estado `Draft`, pero queremos el mismo comportamiento en el estado
+`PendingReview`. ¡El Listado 17-11 ahora funciona hasta la línea 10!
 
 <!-- Old headings. Do not remove or links may break. -->
 <a id="adding-the-approve-method-that-changes-the-behavior-of-content"></a>
 
-### Adding `approve` to Change the Behavior of `content`
+### Agregando `approve` para cambiar el comportamiento de `content`
 
-The `approve` method will be similar to the `request_review` method: it will
-set `state` to the value that the current state says it should have when that
-state is approved, as shown in Listing 17-16:
+El método `approve` será similar al método `request_review`: establecerá el
+valor de `state` al estado que el estado actual indique que debería tener 
+cuando ese estado sea aprobado, como se muestra en el Listado 17-16:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -228,24 +242,24 @@ state is approved, as shown in Listing 17-16:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-16/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-16: Implementing the `approve` method on
-`Post` and the `State` trait</span>
+<span class="caption">Listing 17-16: Implementando el método `approve` en 
+`Post` y el trait `State`</span>
 
-We add the `approve` method to the `State` trait and add a new struct that
-implements `State`, the `Published` state.
+Agregamos el método `approve` al trait `State` y agregamos un nuevo struct
+que implementa el trait `State`, el estado `Published`.
 
-Similar to the way `request_review` on `PendingReview` works, if we call the
-`approve` method on a `Draft`, it will have no effect because `approve` will
-return `self`. When we call `approve` on `PendingReview`, it returns a new,
-boxed instance of the `Published` struct. The `Published` struct implements the
-`State` trait, and for both the `request_review` method and the `approve`
-method, it returns itself, because the post should stay in the `Published`
-state in those cases.
+De manera similar a cómo funciona `request_review` en `PendingReview`, si 
+llamamos al método `approve` en un estado `Draft`, no tendrá efecto porque
+`approve` devolverá `self`. Cuando llamamos a `approve` en `PendingReview`,
+devuelve una nueva instancia de `Published` struct. El struct `Published`
+implementa el trait `State`, y para ambos el método `request_review` y el
+método `approve`, devuelve a sí mismo, porque la publicación debe permanecer
+en el estado `Published` en esos casos.
 
-Now we need to update the `content` method on `Post`. We want the value
-returned from `content` to depend on the current state of the `Post`, so we’re
-going to have the `Post` delegate to a `content` method defined on its `state`,
-as shown in Listing 17-17:
+Ahora debemos actualizar el método `content` en `Post`. Queremos que el valor
+devuelto por `content` dependa del estado actual de `Post`, por lo que vamos
+a hacer que `Post` delegue a un método `content` definido en su `state`, como
+se muestra en el Listado 17-17:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -253,34 +267,35 @@ as shown in Listing 17-17:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-17/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-17: Updating the `content` method on `Post` to
-delegate to a `content` method on `State`</span>
+<span class="caption">Listing 17-17: Actualizando el método `content` en `Post` 
+para delegar en un método `content` en `State`</span>
 
-Because the goal is to keep all these rules inside the structs that implement
-`State`, we call a `content` method on the value in `state` and pass the post
-instance (that is, `self`) as an argument. Then we return the value that’s
-returned from using the `content` method on the `state` value.
+Debido a que el objetivo es mantener todas estas reglas dentro de los structs
+que implementan `State`, llamamos a un método `content` en el valor en `state`
+y pasamos la instancia de publicación (es decir, `self`) como argumento. Luego
+devolvemos el valor devuelto del uso del método `content` en el valor `state`.
 
-We call the `as_ref` method on the `Option` because we want a reference to the
-value inside the `Option` rather than ownership of the value. Because `state`
-is an `Option<Box<dyn State>>`, when we call `as_ref`, an `Option<&Box<dyn
-State>>` is returned. If we didn’t call `as_ref`, we would get an error because
-we can’t move `state` out of the borrowed `&self` of the function parameter.
+Llamamos al método `as_ref` en un `Option` porque queremos una referencia al
+valor dentro del `Option` en lugar del ownership del valor. Debido a que
+`state` es un `Option<Box<dyn State>>`, cuando llamamos a `as_ref`, se
+devuelve una `Option<&Box<dyn State>>`. Si no llamamos a `as_ref`, obtendríamos
+un error porque no podemos mover `state` fuera del `&self` prestado del
+parámetro de la función.
 
-We then call the `unwrap` method, which we know will never panic, because we
-know the methods on `Post` ensure that `state` will always contain a `Some`
-value when those methods are done. This is one of the cases we talked about in
-the [“Cases In Which You Have More Information Than the
-Compiler”][more-info-than-rustc]<!-- ignore --> section of Chapter 9 when we
-know that a `None` value is never possible, even though the compiler isn’t able
-to understand that.
+Luego llamamos al método `unwrap`, el cual sabemos que nunca generará un error,
+porque los métodos en `Post` aseguran que `state` siempre contendrá un valor
+`Some` cuando esos métodos finalicen. Este es uno de los casos que mencionamos
+en la sección [“Casos en los que tienes más información que el
+compilador”][more-info-than-rustc]<!-- ignore --> del Capítulo 9 cuando
+sabemos que un valor `None` nunca es posible, aunque el compilador no puede
+entender eso.
 
-At this point, when we call `content` on the `&Box<dyn State>`, deref coercion
-will take effect on the `&` and the `Box` so the `content` method will
-ultimately be called on the type that implements the `State` trait. That means
-we need to add `content` to the `State` trait definition, and that is where
-we’ll put the logic for what content to return depending on which state we
-have, as shown in Listing 17-18:
+En este punto, cuando llamamos a `content` en el `&Box<dyn State>`, la coerción
+de dereferencia entrará en vigencia en el `&` y el `Box`, por lo que el método
+`content` se llamará en el tipo que implementa el trait `State`. Eso significa
+que debemos agregar `content` a la definición del trait `State`, y allí es
+donde pondremos la lógica para qué contenido devolver dependiendo de qué
+estado tengamos, como se muestra en el Listado 17-18:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -288,100 +303,111 @@ have, as shown in Listing 17-18:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-18/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-18: Adding the `content` method to the `State`
-trait</span>
+<span class="caption">Listing 17-18: Agregando el método `content` al trait
+`State`</span>
 
-We add a default implementation for the `content` method that returns an empty
-string slice. That means we don’t need to implement `content` on the `Draft`
-and `PendingReview` structs. The `Published` struct will override the `content`
-method and return the value in `post.content`.
+Agregamos una implementación predeterminada para el método `content` que
+devuelve un string slice vacío. Eso significa que no necesitamos implementar
+`content` en los structs `Draft` y `PendingReview`. El struct `Published`
+anulará el método `content` y devolverá el valor en `post.content`.
 
-Note that we need lifetime annotations on this method, as we discussed in
-Chapter 10. We’re taking a reference to a `post` as an argument and returning a
-reference to part of that `post`, so the lifetime of the returned reference is
-related to the lifetime of the `post` argument.
+Es importante destacar que necesitamos anotaciones de lifetime en este método,
+como discutimos en el Capítulo 10. Estamos tomando una referencia a un `post`
+como argumento y devolviendo una referencia a una parte de ese `post`, por lo
+que el lifetime de la referencia devuelta está relacionado con el tiempo
+de vida del argumento `post`.
 
-And we’re done—all of Listing 17-11 now works! We’ve implemented the state
-pattern with the rules of the blog post workflow. The logic related to the
-rules lives in the state objects rather than being scattered throughout `Post`.
+¡Y hemos terminado! ¡Todo lo que se muestra en el Listado 17-11 ahora funciona!
+Hemos implementado el patrón de estado con las reglas del flujo de trabajo de
+la publicación de blog. La lógica relacionada con las reglas vive en los
+objetos de estado en lugar de estar dispersa en `Post`.
 
-> #### Why Not An Enum?
+> #### ¿Por qué no un enum?
 >
-> You may have been wondering why we didn’t use an `enum` with the different
-> possible post states as variants. That’s certainly a possible solution, try
-> it and compare the end results to see which you prefer! One disadvantage of
-> using an enum is every place that checks the value of the enum will need a
-> `match` expression or similar to handle every possible variant. This could
-> get more repetitive than this trait object solution.
+> Puede que te hayas preguntado por qué no usamos un `enum` con los diferentes
+> estados posibles de la publicación como variantes. Esa es ciertamente una
+> solución posible, ¡pruébala y compara los resultados finales para ver cuál
+> prefieres! Una desventaja de usar un enum es que cada lugar que verifica el
+> valor del enum necesitará una expresión `match` o similar para manejar cada
+> variante posible. Esto podría ser más repetitivo que esta solución de trait
+> object.
 
-### Trade-offs of the State Pattern
+### Trade-offs del State Pattern
 
-We’ve shown that Rust is capable of implementing the object-oriented state
-pattern to encapsulate the different kinds of behavior a post should have in
-each state. The methods on `Post` know nothing about the various behaviors. The
-way we organized the code, we have to look in only one place to know the
-different ways a published post can behave: the implementation of the `State`
-trait on the `Published` struct.
+Hemos demostrado que Rust es capaz de implementar el State Pattern orientado a
+objetos para encapsular los diferentes tipos de comportamiento que un post
+debería tener en cada estado. Los métodos en `Post` no saben nada sobre los
+diferentes comportamientos. La forma en que organizamos el código, solo
+tenemos que mirar en un solo lugar para conocer las diferentes formas en que
+un post publicado puede comportarse: la implementación del trait `State` en el
+struct `Published`.
 
-If we were to create an alternative implementation that didn’t use the state
-pattern, we might instead use `match` expressions in the methods on `Post` or
-even in the `main` code that checks the state of the post and changes behavior
-in those places. That would mean we would have to look in several places to
-understand all the implications of a post being in the published state! This
-would only increase the more states we added: each of those `match` expressions
-would need another arm.
+Si creáramos una implementación alternativa que no usara el State Pattern,
+en su lugar podríamos usar expresiones `match` en los métodos de `Post` o
+incluso en el código `main` que verifica el estado del post y cambia el
+comportamiento en esos lugares. ¡Eso significaría que tendríamos que mirar en
+varios lugares para comprender todas las implicaciones de un post que se
+encuentra en el estado publicado! ¡Esto solo aumentaría cuanto más estados
+agregáramos: cada una de esas expresiones `match` necesitaría otra opción!
 
-With the state pattern, the `Post` methods and the places we use `Post` don’t
-need `match` expressions, and to add a new state, we would only need to add a
-new struct and implement the trait methods on that one struct.
+Con el State Pattern, los métodos `Post` y los lugares donde usamos `Post` no
+necesitan expresiones `match`, y para agregar un nuevo estado, solo 
+necesitaríamos agregar un nuevo struct e implementar los métodos del trait en 
+ese struct.
 
-The implementation using the state pattern is easy to extend to add more
-functionality. To see the simplicity of maintaining code that uses the state
-pattern, try a few of these suggestions:
+La implementación utilizando el State Pattern es fácil de extender para agregar
+más funcionalidad. Para ver la simplicidad de mantener el código que usa el
+State Pattern, prueba algunas de estas sugerencias:
 
-* Add a `reject` method that changes the post’s state from `PendingReview` back
-  to `Draft`.
-* Require two calls to `approve` before the state can be changed to `Published`.
-* Allow users to add text content only when a post is in the `Draft` state.
-  Hint: have the state object responsible for what might change about the
-  content but not responsible for modifying the `Post`.
+* Agrega un método `reject` que cambia el estado de un post de `PendingReview`
+  a `Draft`.
+* Requiere dos llamadas a `approve` antes de que el estado pueda cambiar a
+  `Published`.
+* Permite a los usuarios agregar contenido de texto solo cuando un post está en
+  el estado `Draft`. Sugerencia: haz que el objeto de estado sea responsable de
+  lo que podría cambiar sobre el contenido, pero no sea responsable de modificar
+  el `Post`.
 
-One downside of the state pattern is that, because the states implement the
-transitions between states, some of the states are coupled to each other. If we
-add another state between `PendingReview` and `Published`, such as `Scheduled`,
-we would have to change the code in `PendingReview` to transition to
-`Scheduled` instead. It would be less work if `PendingReview` didn’t need to
-change with the addition of a new state, but that would mean switching to
-another design pattern.
+Un inconveniente del State Pattern es que, debido a que los estados implementan
+las transiciones entre estados, algunos de los estados están acoplados entre sí.
+Si agregamos otro estado entre `PendingReview` y `Published`, como `Scheduled`,
+tendríamos que cambiar el código en `PendingReview` para hacer la transición a
+`Scheduled` en su lugar. Sería menos trabajo si `PendingReview` no necesitara
+cambiar con la adición de un nuevo estado, pero eso significaría cambiar a
+otro patrón de diseño.
 
-Another downside is that we’ve duplicated some logic. To eliminate some of the
-duplication, we might try to make default implementations for the
-`request_review` and `approve` methods on the `State` trait that return `self`;
-however, this would violate object safety, because the trait doesn’t know what
-the concrete `self` will be exactly. We want to be able to use `State` as a
-trait object, so we need its methods to be object safe.
+Otro inconveniente es que hemos duplicado algo de lógica. Para eliminar parte
+de la duplicación, podríamos intentar hacer implementaciones predeterminadas
+para los métodos `request_review` y `approve` en el trait `State` que devuelvan
+`self`; sin embargo, esto violaría la seguridad del objeto, porque el trait no
+sabe exactamente cuál será el `self` concreto. Queremos poder usar `State` como
+un objeto de trait, por lo que sus métodos deben ser seguros para el objeto.
 
-Other duplication includes the similar implementations of the `request_review`
-and `approve` methods on `Post`. Both methods delegate to the implementation of
-the same method on the value in the `state` field of `Option` and set the new
-value of the `state` field to the result. If we had a lot of methods on `Post`
-that followed this pattern, we might consider defining a macro to eliminate the
-repetition (see the [“Macros”][macros]<!-- ignore --> section in Chapter 19).
+Otra duplicación incluye las implementaciones similares de los métodos
+`request_review` y `approve` en `Post`. Ambos métodos delegan a la
+implementación del mismo método en el valor del campo `state` de `Option` y
+establecen el nuevo valor del campo `state` en el resultado. Si tuviéramos
+muchos métodos en `Post` que siguieran este patrón, podríamos considerar
+definir un macro para eliminar la repetición (ver la sección [“Macros”][macros]
+en el Capítulo 19).
 
-By implementing the state pattern exactly as it’s defined for object-oriented
-languages, we’re not taking as full advantage of Rust’s strengths as we could.
-Let’s look at some changes we can make to the `blog` crate that can make
-invalid states and transitions into compile time errors.
+Al implementar el State Pattern exactamente como se define en lenguajes 
+orientados a objetos, no estamos aprovechando al máximo las fortalezas de Rust.
+Veamos algunos cambios que podemos hacer en el crate `blog` que pueden hacer
+que los estados y transiciones no válidos sean errores de tiempo de 
+compilación.
 
-#### Encoding States and Behavior as Types
+#### Codificando estados y comportamiento como tipos
 
-We’ll show you how to rethink the state pattern to get a different set of
-trade-offs. Rather than encapsulating the states and transitions completely so
-outside code has no knowledge of them, we’ll encode the states into different
-types. Consequently, Rust’s type checking system will prevent attempts to use
-draft posts where only published posts are allowed by issuing a compiler error.
+Vamos a mostrarte cómo replantear el State Patter para obtener un conjunto
+diferente de compensaciones. En lugar de encapsular los estados y las
+transiciones por completo para que el código externo no tenga conocimiento de
+ellos, codificaremos los estados en diferentes tipos. En consecuencia, el
+sistema de verificación de tipos de Rust evitará los intentos de usar 
+publicaciones borradores donde solo se permiten publicaciones publicadas 
+emitiendo un error del compilador.
 
-Let’s consider the first part of `main` in Listing 17-11:
+Consideremos la primera parte de `main` en el Listado 17-11:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -389,15 +415,17 @@ Let’s consider the first part of `main` in Listing 17-11:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-11/src/main.rs:here}}
 ```
 
-We still enable the creation of new posts in the draft state using `Post::new`
-and the ability to add text to the post’s content. But instead of having a
-`content` method on a draft post that returns an empty string, we’ll make it so
-draft posts don’t have the `content` method at all. That way, if we try to get
-a draft post’s content, we’ll get a compiler error telling us the method
-doesn’t exist. As a result, it will be impossible for us to accidentally
-display draft post content in production, because that code won’t even compile.
-Listing 17-19 shows the definition of a `Post` struct and a `DraftPost` struct,
-as well as methods on each:
+Todavía permitimos la creación de nuevas publicaciones en el estado de borrador
+usando `Post::new` y la capacidad de agregar texto al contenido de la 
+publicación. Pero en lugar de tener un método `content` en una publicación en
+borrador que devuelva un string vacío, haremos que las publicaciones en
+borrador no tengan el método `content` en absoluto. De esa manera, si
+intentamos obtener el contenido de una publicación en borrador, obtendremos un
+error del compilador que nos dice que el método no existe. Como resultado,
+será imposible mostrar accidentalmente el contenido de la publicación en
+borrador en producción, porque ese código ni siquiera se compilará. El Listado
+17-9 muestra la definición de un struct `Post` y un struct `DraftPost`, así
+como métodos en cada uno:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -405,35 +433,38 @@ as well as methods on each:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-19/src/lib.rs}}
 ```
 
-<span class="caption">Listing 17-19: A `Post` with a `content` method and a
-`DraftPost` without a `content` method</span>
+<span class="caption">Listing 17-19: Un `Post` con un método `content` y un
+`DraftPost` sin un método `content`</span>
 
-Both the `Post` and `DraftPost` structs have a private `content` field that
-stores the blog post text. The structs no longer have the `state` field because
-we’re moving the encoding of the state to the types of the structs. The `Post`
-struct will represent a published post, and it has a `content` method that
-returns the `content`.
+Tanto los structs `Post` como `DraftPost` tienen un campo privado `content`
+que almacena el texto de la publicación del blog. Los structs ya no tienen el
+campo `state` porque estamos moviendo la codificación del estado a los tipos
+de los structs. El struct `Post` representará una publicación publicada, y
+tiene un método `content` que devuelve el `content`.
 
-We still have a `Post::new` function, but instead of returning an instance of
-`Post`, it returns an instance of `DraftPost`. Because `content` is private
-and there aren’t any functions that return `Post`, it’s not possible to create
-an instance of `Post` right now.
+Todavía tenemos una función `Post::new`, pero en lugar de devolver una 
+instancia de `Post`, devuelve una instancia de `DraftPost`. Debido a que
+`content` es privado y no hay funciones que devuelvan `Post`, no es posible
+crear una instancia de `Post` en este momento.
 
-The `DraftPost` struct has an `add_text` method, so we can add text to
-`content` as before, but note that `DraftPost` does not have a `content` method
-defined! So now the program ensures all posts start as draft posts, and draft
-posts don’t have their content available for display. Any attempt to get around
-these constraints will result in a compiler error.
+El struct `DraftPost` tiene un método `add_text`, por lo que podemos agregar
+texto al campo `content` como antes. Sin embargo, ten en cuenta que `DraftPost`
+no tiene un método `content` definido. Entonces, ahora el programa garantiza
+que todas las publicaciones comienzan como publicaciones en borrador, y las
+publicaciones en borrador no tienen su contenido disponible para mostrar.
+Cualquier intento de evitar estas restricciones dará como resultado un error
+del compilador.
 
-#### Implementing Transitions as Transformations into Different Types
+#### Implementando transiciones como transformaciones en diferentes tipos
 
-So how do we get a published post? We want to enforce the rule that a draft
-post has to be reviewed and approved before it can be published. A post in the
-pending review state should still not display any content. Let’s implement
-these constraints by adding another struct, `PendingReviewPost`, defining the
-`request_review` method on `DraftPost` to return a `PendingReviewPost`, and
-defining an `approve` method on `PendingReviewPost` to return a `Post`, as
-shown in Listing 17-20:
+Entonces, ¿cómo obtenemos una publicación publicada? Queremos hacer cumplir
+la regla de que una publicación en borrador debe ser revisada y aprobada antes
+de que pueda publicarse. Una publicación en el estado de revisión pendiente
+todavía no debe mostrar ningún contenido. Implementemos estas restricciones
+agregando otro struct, `PendingReviewPost`, definiendo el método `request_review`
+en `DraftPost` para devolver un `PendingReviewPost`, y definiendo un método
+`approve` en `PendingReviewPost` para devolver un `Post`, como se muestra en
+el Listado 17-20:
 
 <span class="filename">Filename: src/lib.rs</span>
 
@@ -441,29 +472,31 @@ shown in Listing 17-20:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-20/src/lib.rs:here}}
 ```
 
-<span class="caption">Listing 17-20: A `PendingReviewPost` that gets created by
-calling `request_review` on `DraftPost` and an `approve` method that turns a
-`PendingReviewPost` into a published `Post`</span>
+<span class="caption">Listing 17-20: Un `PendingReviewPost` que se crea 
+llamando a `request_review` en `DraftPost` y un método `approve` que convierte
+un `PendingReviewPost` en un `Post` publicado</span>
 
-The `request_review` and `approve` methods take ownership of `self`, thus
-consuming the `DraftPost` and `PendingReviewPost` instances and transforming
-them into a `PendingReviewPost` and a published `Post`, respectively. This way,
-we won’t have any lingering `DraftPost` instances after we’ve called
-`request_review` on them, and so forth. The `PendingReviewPost` struct doesn’t
-have a `content` method defined on it, so attempting to read its content
-results in a compiler error, as with `DraftPost`. Because the only way to get a
-published `Post` instance that does have a `content` method defined is to call
-the `approve` method on a `PendingReviewPost`, and the only way to get a
-`PendingReviewPost` is to call the `request_review` method on a `DraftPost`,
-we’ve now encoded the blog post workflow into the type system.
+Los métodos `request_review` y `approve` toman ownership de `self`, consumiendo
+así las instancias de `DraftPost` y `PendingReviewPost` y transformándolas en
+un `PendingReviewPost` y un `Post` publicado, respectivamente. De esta manera,
+no tendremos ninguna instancia de `DraftPost` persistente después de haber
+llamado a `request_review` en ellas, y así sucesivamente. El struct
+`PendingReviewPost` no tiene un método `content` definido en él, por lo que
+intentar leer su contenido da como resultado un error del compilador, como con
+`DraftPost`. Debido a que la única forma de obtener una instancia de `Post`
+publicada que tiene un método `content` definido es llamar al método `approve`
+en un `PendingReviewPost`, y la única forma de obtener un `PendingReviewPost`
+es llamar al método `request_review` en un `DraftPost`, ahora hemos codificado
+el workflow de la publicación del blog en el sistema de tipos.
 
-But we also have to make some small changes to `main`. The `request_review` and
-`approve` methods return new instances rather than modifying the struct they’re
-called on, so we need to add more `let post =` shadowing assignments to save
-the returned instances. We also can’t have the assertions about the draft and
-pending review posts’ contents be empty strings, nor do we need them: we can’t
-compile code that tries to use the content of posts in those states any longer.
-The updated code in `main` is shown in Listing 17-21:
+Pero también debemos hacer algunos cambios pequeños en `main`. Los métodos
+`request_review` y `approve` devuelven nuevas instancias en lugar de modificar
+el struct en el que se llaman, por lo que debemos agregar más asignaciones de
+sombreado `let post =` para guardar las instancias devueltas. Tampoco podemos
+tener las afirmaciones sobre el contenido de las publicaciones en borrador y
+revisión pendiente sean strings vacíos, ni los necesitamos: ya no podemos
+compilar el código que intenta usar el contenido de las publicaciones en esos
+estados. El código actualizado en `main` se muestra en el Listado 17-21:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -471,46 +504,49 @@ The updated code in `main` is shown in Listing 17-21:
 {{#rustdoc_include ../listings/ch17-oop/listing-17-21/src/main.rs}}
 ```
 
-<span class="caption">Listing 17-21: Modifications to `main` to use the new
-implementation of the blog post workflow</span>
+<span class="caption">Listing 17-21: Modificaciones a `main` para usar la nueva
+implementación del workflow de la publicación del blog</span>
 
-The changes we needed to make to `main` to reassign `post` mean that this
-implementation doesn’t quite follow the object-oriented state pattern anymore:
-the transformations between the states are no longer encapsulated entirely
-within the `Post` implementation. However, our gain is that invalid states are
-now impossible because of the type system and the type checking that happens at
-compile time! This ensures that certain bugs, such as display of the content of
-an unpublished post, will be discovered before they make it to production.
+Las modificaciones que hicimos a `main` para reasignar `post` significan que
+esta implementación ya no sigue el patrón de estado orientado a objetos: las
+transformaciones entre los estados ya no están encapsuladas completamente
+dentro de la implementación de `Post`. Sin embargo, nuestra ganancia es que
+los estados inválidos ahora son imposibles debido al sistema de tipos y la
+comprobación de tipos que ocurre en tiempo de compilación. Esto garantiza que
+ciertos errores, como la visualización del contenido de una publicación no
+publicada, se descubrirán antes de que lleguen a producción.
 
-Try the tasks suggested at the start of this section on the `blog` crate as it
-is after Listing 17-21 to see what you think about the design of this version
-of the code. Note that some of the tasks might be completed already in this
-design.
+Prueba las tareas sugeridas al comienzo de esta sección en el crate `blog` tal
+como está después del Listado 17-21 para evaluar el diseño de esta versión del
+código. Ten en cuenta que es posible que algunas de las tareas ya estén 
+completadas en este diseño.
 
-We’ve seen that even though Rust is capable of implementing object-oriented
-design patterns, other patterns, such as encoding state into the type system,
-are also available in Rust. These patterns have different trade-offs. Although
-you might be very familiar with object-oriented patterns, rethinking the
-problem to take advantage of Rust’s features can provide benefits, such as
-preventing some bugs at compile time. Object-oriented patterns won’t always be
-the best solution in Rust due to certain features, like ownership, that
-object-oriented languages don’t have.
+Hemos visto que aunque Rust es capaz de implementar patrones de diseño 
+orientados a objetos, también están disponibles en Rust otros patrones, como
+la codificación del estado en el sistema de tipos. Estos patrones tienen
+diferentes compensaciones. Aunque es posible que estés muy familiarizado con
+los patrones orientados a objetos, repensar el problema para aprovechar las
+características de Rust puede proporcionar beneficios, como prevenir algunos
+errores en tiempo de compilación. Los patrones orientados a objetos no siempre
+serán la mejor solución en Rust debido a ciertas características, como el
+ownership, que los lenguajes orientados a objetos no tienen.
 
-## Summary
+## Resumen
 
-No matter whether or not you think Rust is an object-oriented language after
-reading this chapter, you now know that you can use trait objects to get some
-object-oriented features in Rust. Dynamic dispatch can give your code some
-flexibility in exchange for a bit of runtime performance. You can use this
-flexibility to implement object-oriented patterns that can help your code’s
-maintainability. Rust also has other features, like ownership, that
-object-oriented languages don’t have. An object-oriented pattern won’t always
-be the best way to take advantage of Rust’s strengths, but is an available
-option.
+Sin importar si consideras a Rust como un lenguaje orientado a objetos después
+de leer este capítulo, ahora sabes que puedes usar objetos de tipo trait para
+obtener algunas características orientadas a objetos en Rust. La 
+despatronización dinámica puede brindarle a tu código cierta flexibilidad a 
+cambio de un poco de rendimiento en tiempo de ejecución. Puedes usar esta
+flexibilidad para implementar patrones orientados a objetos que pueden ayudar
+a la mantenibilidad de tu código. Rust también tiene otras características,
+como el ownership, que los lenguajes orientados a objetos no tienen. Un patrón
+orientado a objetos no siempre será la mejor manera de aprovechar las
+fortalezas de Rust, pero es una opción disponible.
 
-Next, we’ll look at patterns, which are another of Rust’s features that enable
-lots of flexibility. We’ve looked at them briefly throughout the book but
-haven’t seen their full capability yet. Let’s go!
+A continuación, veremos los patterns, que son otra de las características de 
+Rust que permiten mucha flexibilidad. Hemos visto brevemente los patterns a lo
+largo del libro, pero aún no hemos visto su capacidad total. ¡Vamos allá!
 
 [more-info-than-rustc]: ch09-03-to-panic-or-not-to-panic.html#cases-in-which-you-have-more-information-than-the-compiler
 [macros]: ch19-06-macros.html#macros


### PR DESCRIPTION
Traduje el capítulo 17 sobre la POO (Programación Orientada a Objetos) en Rust